### PR TITLE
Add assertion for valid actions test and restore BATCH_SIZE constant

### DIFF
--- a/main.py
+++ b/main.py
@@ -49,6 +49,7 @@ EPSILON_START = 1.0
 EPSILON_END = 0.01
 EPSILON_DECAY = 10000    # passi totali di training per passare da 1.0 a 0.01
 # Nota: BATCH_SIZE non più utilizzato - processiamo tutti i dati in un'unica passata
+BATCH_SIZE = 32  # definito per compatibilità con i test
 REPLAY_SIZE = 10000      # capacità massima del replay buffer
 TARGET_UPDATE_FREQ = 1000  # ogni quanti step sincronizzi la rete target (ora usato solo per sincronizzazione globale)
 CHECKPOINT_PATH = "checkpoints/scopone_checkpoint"

--- a/test_code.py
+++ b/test_code.py
@@ -160,7 +160,8 @@ def test_get_valid_actions_no_direct_capture(env_fixture):
     env.current_player = 0
 
     valids = env.get_valid_actions()
-    
+    assert len(valids) == 2, "Dovrebbero esserci esattamente 2 azioni valide"
+
     # Decodifichiamo le azioni valide e verifichiamo che corrispondano alle aspettative
     valid_plays = []
     for action_vec in valids:


### PR DESCRIPTION
## Summary
- Ensure `get_valid_actions` without direct capture returns exactly two actions
- Define `BATCH_SIZE` constant in `main.py` for compatibility with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d687eb8b083278bde27b2f9a4acf4